### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,12 @@ test_requirements = [ ]
 setup(
     author="Container Solutions",
     author_email='cre@container-solutions.com',
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 2 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py35, py36, py37, py38, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:flake8]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,6 @@
 [tox]
 envlist = py36, py37, py38, flake8
 
-[travis]
-python =
-    3.8: py38
-    3.7: py37
-    3.6: py36
-
 [testenv:flake8]
 basepython = python
 deps = flake8


### PR DESCRIPTION
Python3.5 is EOLed, tools are dropping support. We may as well do that too.
Also, removed some unused travis config from `tox.ini`.